### PR TITLE
Support byte array as content argument

### DIFF
--- a/Plugins/WebGLFileSaver.jslib
+++ b/Plugins/WebGLFileSaver.jslib
@@ -154,8 +154,7 @@ mergeInto(LibraryManager.library, {
     },	
 	UNITY_SAVE: function (content, name, mimetype)
 	{
-		var blob = new Blob([Pointer_stringify(content)], {type: "text/plain;charset=utf-8"});
-        var blob = new Blob([Pointer_stringify(content)], {type: Pointer_stringify(mimetype)})
+        var blob = new Blob([Pointer_stringify(content)], { type: Pointer_stringify(mimetype) });
 		saveAs(blob, Pointer_stringify(name));
 	},
 	UNITY_IS_SUPPORTED: function ()

--- a/Plugins/WebGLFileSaver.jslib
+++ b/Plugins/WebGLFileSaver.jslib
@@ -157,6 +157,13 @@ mergeInto(LibraryManager.library, {
         var blob = new Blob([Pointer_stringify(content)], { type: Pointer_stringify(mimetype) });
 		saveAs(blob, Pointer_stringify(name));
 	},
+    UNITY_SAVE_BYTEARRAY: function (arr, size, name, mimetype)
+    {
+        var bytes = new Uint8Array(size);
+        for (var i = 0; i < size; i++) bytes[i] = HEAPU8[arr + i];
+        var blob = new Blob([bytes], { type: Pointer_stringify(mimetype) });
+        saveAs(blob, Pointer_stringify(name));
+    },
 	UNITY_IS_SUPPORTED: function ()
 	{
 		try 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The WebGLFileSaver class has two static functions to use:
 	This returns a boolean value of whether saving is supported on the current OS and Browser or not.
 
 2) `public static void SaveFile(string content, string filename, string MIMEType)`
+	`public static void SaveFile(byte[] content, string filename, string MIMEType)`
 	This prompts the user to download a file named 'filename', with the content 'content'.
 	The MIMEType is the file type that will allow the browser to open the file with a default program.
 		It can be set to any values in the IANA Media Types (https://www.iana.org/assignments/media-types/media-types.xhtml )

--- a/WebGLFileSaver.cs
+++ b/WebGLFileSaver.cs
@@ -8,6 +8,9 @@ public class WebGLFileSaver
 
     [DllImport("__Internal")]
     private static extern void UNITY_SAVE(string content, string name, string MIMEType);
+    
+    [DllImport ("__Internal")]
+    private static extern void UNITY_SAVE_BYTEARRAY(byte[] array, int byteLength, string name, string MIMEType);
 
     [DllImport("__Internal")]
     private static extern void init();
@@ -19,15 +22,34 @@ public class WebGLFileSaver
 
     public static void SaveFile(string content, string fileName, string MIMEType = "text/plain;charset=utf-8")
     {
+       if (!CheckSupportAndInit()) return;
+
+        UNITY_SAVE (content, fileName, MIMEType);
+    }
+    
+    public static void SaveFile(byte[] content, string fileName, string MIMEType = "text/plain;charset=utf-8")
+    {
+        if (content == null)
+        {
+            Debug.LogError("null parameter passed for content byte array");
+            return;
+        }
+        if (!CheckSupportAndInit()) return;
+
+        UNITY_SAVE_BYTEARRAY (content, content.Length, fileName, MIMEType);
+    }
+
+    static bool CheckSupportAndInit()
+    {
         if (Application.isEditor)
         {
             Debug.Log("Saving will not work in editor.");
-            return;
+            return false;
         }
         if (Application.platform != RuntimePlatform.WebGLPlayer)
         {
             Debug.Log("Saving must be on a WebGL build.");
-            return;
+            return false;
         }
 
         CheckInit();
@@ -35,9 +57,9 @@ public class WebGLFileSaver
         if (!IsSavingSupported())
         { 
             Debug.LogWarning("Saving is not supported on this device.");
-            return;
+            return false;
         }
-        UNITY_SAVE(content, fileName, MIMEType);
+        return true;
     }
 
     static void CheckInit()


### PR DESCRIPTION
Add function overload for SaveFile() which accepts byte[] as argument, enabling binary files to be downloaded uncorrupted.

See working demo project:

[WebGLFileSaverTest.zip](https://github.com/Nateonus/WebGLFileSaverForUnity/files/7024581/WebGLFileSaverTest.zip)